### PR TITLE
Adapt to support SQLite

### DIFF
--- a/db/migrate/20230804105731_create_editorjs_rails_texts.rb
+++ b/db/migrate/20230804105731_create_editorjs_rails_texts.rb
@@ -1,9 +1,26 @@
 class CreateEditorjsRailsTexts < ActiveRecord::Migration[7.0]
   def change
-    create_table :editorjs_rails_texts, id: :uuid do |t|
+    # Determine database adapter
+    adapter_type = connection.adapter_name.downcase
+    use_uuid = adapter_type.include?('postgresql')
+
+    # Create table with appropriate ID type
+    create_table :editorjs_rails_texts, id: (use_uuid ? :uuid : :primary_key) do |t|
       t.string :name, null: false
-      t.jsonb :content, default: {}
-      t.references :record, null: false, polymorphic: true, index: false, type: :uuid
+
+      # Use jsonb for PostgreSQL, text for SQLite and others
+      if use_uuid
+        t.jsonb :content, default: {}
+      else
+        t.json :content, default: '{}'
+      end
+
+      # Polymorphic reference with appropriate type
+      if use_uuid
+        t.references :record, null: false, polymorphic: true, index: false, type: :uuid
+      else
+        t.references :record, null: false, polymorphic: true, index: false
+      end
 
       t.timestamps
     end


### PR DESCRIPTION
When installing editorjs on the latest Rails 8.0 vanilla release, sqlite3 is chosen as the default database configuration.

This PR fixes the installed migrations by detecting whether the adaptor is postgres, and selectively applies the `jsonb` column and `uuid` instructions in that case.